### PR TITLE
fix: correct add() function to return a + b

### DIFF
--- a/src/calc.js
+++ b/src/calc.js
@@ -1,5 +1,3 @@
 export function add(a, b) {
-  // BUG (intentional): demo PR will fix this to `a + b`
-  return a - b;
+  return a + b;
 }
-


### PR DESCRIPTION
Fixes the intentional bug in `src/calc.js` where `add(a, b)` was returning `a - b` instead of `a + b`.

Closes #1